### PR TITLE
Add React Native skeleton app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # mami
-muhasebe
+
+This repository contains a skeletal React Native application for managing university-related finances.
+
+The `mami_app` folder holds the app source code. See `mami_app/README.md` for details on building and running the project.

--- a/mami_app/App.js
+++ b/mami_app/App.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import UniversityExpenses from './src/modules/UniversityExpenses';
+import ClubBudgets from './src/modules/ClubBudgets';
+import ProjectAllowances from './src/modules/ProjectAllowances';
+import StaffSalaries from './src/modules/StaffSalaries';
+import { RoleProvider, useRole } from './src/auth/RoleContext';
+import { Button, View, Text } from 'react-native';
+
+const Stack = createStackNavigator();
+
+function HomeScreen({ navigation }) {
+  const { role, signIn, signOut } = useRole();
+  return (
+    <View>
+      <Text>Role: {role || 'guest'}</Text>
+      {role ? (
+        <Button title="Sign Out" onPress={signOut} />
+      ) : (
+        <Button title="Sign In as Accountant" onPress={() => signIn('accountant')} />
+      )}
+      <Button title="University Expenses" onPress={() => navigation.navigate('UniversityExpenses')} />
+      <Button title="Club Budgets" onPress={() => navigation.navigate('ClubBudgets')} />
+      <Button title="Project Allowances" onPress={() => navigation.navigate('ProjectAllowances')} />
+      <Button title="Staff Salaries" onPress={() => navigation.navigate('StaffSalaries')} />
+    </View>
+  );
+}
+
+export default function App() {
+  return (
+    <RoleProvider>
+      <NavigationContainer>
+        <Stack.Navigator initialRouteName="Home">
+          <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="UniversityExpenses" component={UniversityExpenses} />
+          <Stack.Screen name="ClubBudgets" component={ClubBudgets} />
+          <Stack.Screen name="ProjectAllowances" component={ProjectAllowances} />
+          <Stack.Screen name="StaffSalaries" component={StaffSalaries} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </RoleProvider>
+  );
+}

--- a/mami_app/README.md
+++ b/mami_app/README.md
@@ -1,0 +1,30 @@
+# mami_app
+
+This is a skeleton React Native application for managing various financial records.
+
+## Modules
+- **University Expenses**
+- **Club Budgets**
+- **Project Allowances**
+- **Staff Salaries**
+
+Role-based authentication is implemented via a simple context provider. Only users signed in as `accountant` can add or modify financial data.
+
+The app is configured to use Firebase as the cloud backend (see dependencies in `package.json`). You will need to add your Firebase configuration and install dependencies with `npm install` before building.
+
+## Building and Running
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Start Metro bundler:
+   ```bash
+   npm start
+   ```
+3. In a separate terminal run:
+   ```bash
+   npm run android   # or npm run ios
+   ```
+
+Due to environment limitations in this repository, the full React Native CLI was not initialized via `npx react-native init`. Instead, a minimal project structure has been created manually.

--- a/mami_app/package.json
+++ b/mami_app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mami_app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "react-native start",
+    "android": "react-native run-android",
+    "ios": "react-native run-ios"
+  },
+  "dependencies": {
+    "react": "18.2.0",
+    "react-native": "0.73.4",
+    "@react-native-firebase/app": "18.6.0",
+    "@react-native-firebase/auth": "18.6.0"
+  },
+  "devDependencies": {
+    "@babel/core": "7.24.5"
+  }
+}

--- a/mami_app/src/auth/RoleContext.js
+++ b/mami_app/src/auth/RoleContext.js
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const RoleContext = createContext();
+
+export function RoleProvider({ children }) {
+  const [role, setRole] = useState(null);
+
+  const signIn = (newRole) => setRole(newRole);
+  const signOut = () => setRole(null);
+
+  return (
+    <RoleContext.Provider value={{ role, signIn, signOut }}>
+      {children}
+    </RoleContext.Provider>
+  );
+}
+
+export function useRole() {
+  return useContext(RoleContext);
+}

--- a/mami_app/src/modules/ClubBudgets.js
+++ b/mami_app/src/modules/ClubBudgets.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, FlatList } from 'react-native';
+import { useRole } from '../auth/RoleContext';
+
+export default function ClubBudgets() {
+  const { role } = useRole();
+  const [budgets, setBudgets] = useState([]);
+  const [value, setValue] = useState('');
+
+  const addBudget = () => {
+    if (!value) return;
+    setBudgets([...budgets, { id: Date.now().toString(), value }]);
+    setValue('');
+  };
+
+  return (
+    <View>
+      <FlatList
+        data={budgets}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => <Text>{item.value}</Text>}
+      />
+      {role === 'accountant' && (
+        <>
+          <TextInput placeholder="New budget" value={value} onChangeText={setValue} />
+          <Button title="Add" onPress={addBudget} />
+        </>
+      )}
+    </View>
+  );
+}

--- a/mami_app/src/modules/ProjectAllowances.js
+++ b/mami_app/src/modules/ProjectAllowances.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, FlatList } from 'react-native';
+import { useRole } from '../auth/RoleContext';
+
+export default function ProjectAllowances() {
+  const { role } = useRole();
+  const [allowances, setAllowances] = useState([]);
+  const [value, setValue] = useState('');
+
+  const addAllowance = () => {
+    if (!value) return;
+    setAllowances([...allowances, { id: Date.now().toString(), value }]);
+    setValue('');
+  };
+
+  return (
+    <View>
+      <FlatList
+        data={allowances}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => <Text>{item.value}</Text>}
+      />
+      {role === 'accountant' && (
+        <>
+          <TextInput placeholder="New allowance" value={value} onChangeText={setValue} />
+          <Button title="Add" onPress={addAllowance} />
+        </>
+      )}
+    </View>
+  );
+}

--- a/mami_app/src/modules/StaffSalaries.js
+++ b/mami_app/src/modules/StaffSalaries.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, FlatList } from 'react-native';
+import { useRole } from '../auth/RoleContext';
+
+export default function StaffSalaries() {
+  const { role } = useRole();
+  const [salaries, setSalaries] = useState([]);
+  const [value, setValue] = useState('');
+
+  const addSalary = () => {
+    if (!value) return;
+    setSalaries([...salaries, { id: Date.now().toString(), value }]);
+    setValue('');
+  };
+
+  return (
+    <View>
+      <FlatList
+        data={salaries}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => <Text>{item.value}</Text>}
+      />
+      {role === 'accountant' && (
+        <>
+          <TextInput placeholder="New salary" value={value} onChangeText={setValue} />
+          <Button title="Add" onPress={addSalary} />
+        </>
+      )}
+    </View>
+  );
+}

--- a/mami_app/src/modules/UniversityExpenses.js
+++ b/mami_app/src/modules/UniversityExpenses.js
@@ -1,0 +1,31 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, Button, FlatList } from 'react-native';
+import { useRole } from '../auth/RoleContext';
+
+export default function UniversityExpenses() {
+  const { role } = useRole();
+  const [expenses, setExpenses] = useState([]);
+  const [value, setValue] = useState('');
+
+  const addExpense = () => {
+    if (!value) return;
+    setExpenses([...expenses, { id: Date.now().toString(), value }]);
+    setValue('');
+  };
+
+  return (
+    <View>
+      <FlatList
+        data={expenses}
+        keyExtractor={item => item.id}
+        renderItem={({ item }) => <Text>{item.value}</Text>}
+      />
+      {role === 'accountant' && (
+        <>
+          <TextInput placeholder="New expense" value={value} onChangeText={setValue} />
+          <Button title="Add" onPress={addExpense} />
+        </>
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- set up a minimal React Native project under `mami_app`
- implement example modules for expenses, budgets, allowances and salaries
- add simple role-based auth context
- document build steps and environment limitations

## Testing
- `npx react-native init mami_app` *(fails: 403 Forbidden)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6853230aaae0832eadc22da5fe530c27