### PR TITLE
Add Jest tests and CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,20 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main", "work" ]
+  pull_request:
+    branches: [ "main", "work" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+    - run: npm install
+    - run: npm test

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,0 +1,25 @@
+const { authenticateUser, addEntry, calculateBudget } = require('../src');
+
+describe('authentication', () => {
+  test('valid credentials', () => {
+    expect(authenticateUser('user', 'password')).toBe(true);
+  });
+  test('invalid credentials', () => {
+    expect(authenticateUser('u', 'p')).toBe(false);
+  });
+});
+
+describe('data entry', () => {
+  test('adds entry to list', () => {
+    const entries = [];
+    addEntry({ amount: 5 }, entries);
+    expect(entries.length).toBe(1);
+  });
+});
+
+describe('budget calculations', () => {
+  test('sums amounts', () => {
+    const entries = [{ amount: 2 }, { amount: 3 }];
+    expect(calculateBudget(entries)).toBe(5);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mami",
+  "version": "1.0.0",
+  "description": "muhasebe",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,14 @@
+function authenticateUser(username, password) {
+  return username === 'user' && password === 'password';
+}
+
+function addEntry(entry, entries) {
+  entries.push(entry);
+  return entries;
+}
+
+function calculateBudget(entries) {
+  return entries.reduce((sum, e) => sum + (e.amount || 0), 0);
+}
+
+module.exports = { authenticateUser, addEntry, calculateBudget };


### PR DESCRIPTION
## Summary
- initialize Node project for React Native style tests
- add basic functions and Jest tests for auth, data entry and budget calculations
- set up GitHub Actions to run tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68532354b2e0832e8bb6ba4384ece15d